### PR TITLE
Make library compatible with the browser

### DIFF
--- a/faststats.js
+++ b/faststats.js
@@ -581,7 +581,7 @@ Stats.prototype.μ=Stats.prototype.amean;
 
 exports.Stats = Stats;
 
-if(process.argv[1] && process.argv[1].match(__filename)) {
+if(typeof process !== 'undefined' && process.argv[1] && process.argv[1].match(__filename)) {
 	var s = new Stats({store_data:false, buckets: [ 1, 5, 10, 15, 20, 25, 30, 35 ]}).push(1, 2, 3);
 	var l = process.argv.slice(2);
 	if(!l.length) l = [10, 11, 15, 8, 13, 12, 19, 32, 17, 16];


### PR DESCRIPTION
This fix addresses #16, which points out two problems when using this library in the browser. 

1. The global `process` variable, which is not defined in browsers, causes a ReferenceError. We fixed this by adding a guard for the `process` variable. 

2. This library is written as a CommonJS module, which is not directly consumable from the browser. We don't believe we need to do anything about this problem because most people use a bundler (e.g. Webpack) nowadays that knows how to consume CommonJS modules. 

Closes #16