### PR TITLE
Fix bug that calculates wrong min value on item removal

### DIFF
--- a/faststats.js
+++ b/faststats.js
@@ -181,12 +181,13 @@ Stats.prototype = {
 			else if(tuple[0] > 0 && (this.max === a || this.min === a)) {
 				var i = this.length-1;
 				if(i>=0) {
-					this.max = this.min = this.data[i--];
-					while(i-- >= 0) {
+					this.max = this.min = this.data[i];
+					while(i >= 0) {
 						if(this.max < this.data[i])
 							this.max = this.data[i];
 						if(this.min > this.data[i])
 							this.min = this.data[i];
+						i--;
 					}
 				}
 			}

--- a/faststats.js
+++ b/faststats.js
@@ -182,12 +182,11 @@ Stats.prototype = {
 				var i = this.length-1;
 				if(i>=0) {
 					this.max = this.min = this.data[i];
-					while(i >= 0) {
+					while(i-- >= 0) {
 						if(this.max < this.data[i])
 							this.max = this.data[i];
 						if(this.min > this.data[i])
 							this.min = this.data[i];
-						i--;
 					}
 				}
 			}


### PR DESCRIPTION
The iteration index is incorrectly decremented twice before entering the first round of the loop. Furthermore the postfix decrement allows negative index in loop which will fetch from the end of the array (and not throw out of bounds)